### PR TITLE
return EINVAL instead of ENOTTY to support custom IOCTLs

### DIFF
--- a/metadata/policy.go
+++ b/metadata/policy.go
@@ -118,6 +118,13 @@ func setPolicy(file *os.File, arg unsafe.Pointer) error {
                 log.Printf("FS_IOC_SET_ENCRYPTION_KEY_RESTRICTED");
                 _, _, errno = unix.Syscall(unix.SYS_IOCTL, file.Fd(), uintptr(C.fs_ioc_set_encryption_policy_restricted), uintptr(arg))
         }
+	// there is some code (e.g. CheckSupport) that calls this function with assumption that it will fail
+        // and return EINVAL.
+        // as a temp solution, we will return EINVAL if the restricted policy fails (and returns ENOTTY)
+        if errno == unix.ENOTTY {
+                log.Printf("returning EINVAL instead of ENOTTY")
+                return unix.EINVAL
+        }	
 	if errno != 0 {
 		return errno
 	}


### PR DESCRIPTION
Fix the return value from `setPolicy` function to `EINVAL` instread of `ENOTTY`.
When the  `setPolicy` function is called with incorrect parameter (on purpose), the calling code expects the `EINVAL` to continue as designed.
With our custom IOCTL code, we return the error code from kernel, which in this case will be `ENOTTY` and it causes the fscrypt code to fail (while determining whether given fs supports encryption).
This is temporary solution IMO.